### PR TITLE
Feature/texture formats

### DIFF
--- a/callbacks.xml
+++ b/callbacks.xml
@@ -159,4 +159,17 @@
         <return>
         </return>
     </command>
+    <command name="setExportTextureFormat">
+        <description>Set the image format (bmp, png, jpg) in which textures are exported.</description>
+        <params>
+            <param name="format" type="string">
+                <description>texure format (bmp, png, jpg(jpeg))</description>
+            </param>
+        </params>
+        <return>
+            <param name="result" type="bool">
+                <description>false if non-available texture format is passed</description>
+            </param>
+        </return>
+    </command>
 </plugin>

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -448,7 +448,16 @@ public:
         int width = res[0];
         int height = res[1];
         std::vector<unsigned char> buffer;
-        auto result = stbi_write_jpg_to_func(to_mem, &buffer, width, height, bytesPerPixel, data, quality);
+        auto result = stbi_write_jpg_to_func(stbi_write_func_vector, &buffer, width, height, bytesPerPixel, data, quality);
+        return buffer;
+    }
+
+    std::vector<unsigned char> raw2png(const unsigned char *data, int res[2], int bytesPerPixel, int stride_bytes)
+    {
+        int width = res[0];
+        int height = res[1];
+        std::vector<unsigned char> buffer;
+        auto result = stbi_write_png_to_func(stbi_write_func_vector, &buffer, width, height, bytesPerPixel, data, stride_bytes);
         return buffer;
     }
 
@@ -462,6 +471,7 @@ public:
         sim::addLog(sim_verbosity_debug, "addImage: loading texture of object %s with id %d %s", objname, id, buf2str(imgdata, res[0] * res[1] * 4));
 #if 0
         auto buf = raw2bmp(reinterpret_cast<const unsigned char *>(imgdata), res, 4);
+        auto buf = raw2png(reinterpret_cast<const unsigned char *>(imgdata), res, 4, res[0]*4);
 #endif
         auto buf = raw2jpg(reinterpret_cast<const unsigned char *>(imgdata), res, 4, 100);
         std::string name = (boost::format("texture image %d [%s] (%dx%d, BMP %d bytes)") % id % objname % res[0] % res[1] % buf.size()).str();

--- a/simAddOnFunc_gltfExporter.lua
+++ b/simAddOnFunc_gltfExporter.lua
@@ -4,6 +4,7 @@ if sceneName==nil then sceneName='untitled' end
 local fileName=sim.fileDialog(sim.filedlg_type_save,'Export to glTF...',scenePath,sceneName..'.gltf','glTF file','gltf')
 if fileName==nil then return end
 simGLTF.clear()
+--simGLTF.setExportTextureFormat('png') --set texture format before export:'bmp'(default), 'png', 'jpg'
 simGLTF.exportAllObjects()
 simGLTF.saveASCII(fileName)
 sim.addLog(sim.verbosity_infos+sim.verbosity_undecorated,'Exported glTF content to '..fileName)


### PR DESCRIPTION
### Why texture format options?
The current version of simExtGLTF exports texture images in BMP format.
But some tools (blender, official glTF importer for Unity by Khronos, .. ) only support JPG and PNG.
Texture format options are added to handle such use-cases.

### Changes
* Add raw image to jpg and png features (uses stb)
* Add Lua binding 'setExportTextureFormat()'